### PR TITLE
HACK: mmc: only do 8KiB aligned multiblock writes

### DIFF
--- a/drivers/mmc/mmc_write.c
+++ b/drivers/mmc/mmc_write.c
@@ -179,6 +179,12 @@ ulong mmc_bwrite(int dev_num, lbaint_t start, lbaint_t blkcnt, const void *src)
 	do {
 		cur = (blocks_todo > mmc->cfg->b_max) ?
 			mmc->cfg->b_max : blocks_todo;
+		if (cur >= 16)
+			cur -= cur % 16;
+		else
+			cur = 1;
+		if (start & 15)
+			cur = 1;
 		if (mmc_write_blocks(mmc, start, cur, src) != cur)
 			return 0;
 		blocks_todo -= cur;


### PR DESCRIPTION
For edison we are seeing multiblock writes that silently only
partially complete. It's not clear exactly what the alignment
requirement is and I haven't seen any code in the linux kernel for
tangier that applies logic like this, so I'm not sure why this
issue isn't seen there.

Here we add a hack where multiblock writes are only done when the
start address and the length are 8KiB aligned. Other writes are
handled as a series of single block writes.

Change-Id: I03f1e1f3b34a2d511d2c87b309121c285079bc5e
Signed-off-by: Scott D Phillips scott.d.phillips@intel.com
