### PR TITLE
allow the same format for dfu_alt_info as edison-v2014.04

### DIFF
--- a/drivers/dfu/dfu_mmc.c
+++ b/drivers/dfu/dfu_mmc.c
@@ -350,7 +350,8 @@ int dfu_fill_entity_mmc(struct dfu_entity *dfu, char *devstr, char *s)
 	}
 
 	dfu->data.mmc.hw_partition = -EINVAL;
-	if (!strcmp(entity_type, "raw")) {
+	if (!strcmp(entity_type, "raw")
+	    || !strcmp(entity_type, "mmc")) {
 		dfu->layout			= DFU_RAW_ADDR;
 		dfu->data.mmc.lba_start		= second_arg;
 		dfu->data.mmc.lba_size		= third_arg;


### PR DESCRIPTION
2015.10 has a different dfu_alt_info format than 2014.04.  I'd argue that 2015's is slightly better, but there's not really any reason they can't both work together.
